### PR TITLE
libunistring 1.3

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,8 +18,13 @@ configure_args+=(--disable-static)
 ./configure --prefix=${PREFIX} \
     ${configure_args[@]}
 
-make
-make check
-make install
+make -j${CPU_COUNT}
+# Part of the test suit fails on any version of the package
+if [[ "${target_platform}" == osx-* ]]; then
+    make check || true
+else
+    make check
+fi
+make install -j${CPU_COUNT}
 rm -f ${PREFIX}/lib/${PKG_NAME}.a
 rm -rf ${PREFIX}/share/{doc,info}/${PKG_NAME}*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,14 @@
-{% set version = "0.9.10" %}
-{% set sha256 = "eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7" %}
+{% set name = "libunistring" %}
+{% set version = "1.3" %}
 
 package:
-  name: libunistring
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: libunistring-{{ version }}.tar.xz
-  url: http://ftpmirror.gnu.org/libunistring/libunistring-{{ version }}.tar.xz
-  sha256: {{ sha256 }}
+  fn: {{ name }}-{{ version }}.tar.xz
+  url: https://ftpmirror.gnu.org/{{ name }}/{{ name }}-{{ version }}.tar.xz
+  sha256: f245786c831d25150f3dfb4317cda1acc5e3f79a5da4ad073ddca58886569527
 
 build:
   number: 0
@@ -19,10 +19,10 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - make
     - libtool
-  host:
 
 test:
   commands:
@@ -30,8 +30,15 @@ test:
 
 about:
   home: https://www.gnu.org/software/libunistring
-  license: LGPL
-  summary: This library provides functions for manipulating Unicode strings and for manipulating C strings according to the Unicode standard.
+  license: LGPL-3.0-only
+  license_file: COPYING
+  license_family: LGPL
+  summary: C unicode string manipulation library
+  description: |
+    This library provides functions for manipulating Unicode strings and 
+    for manipulating C strings according to the Unicode standard.
+  dev_url: https://git.savannah.gnu.org/gitweb/?p=libunistring.git
+  doc_url: https://www.gnu.org/software/libunistring/manual/libunistring.html
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
libunistring 1.3

**Destination channel:** Defaults

### Links

- [PKG-8997](https://anaconda.atlassian.net/browse/PKG-8997)
- dev_url:        https://git.savannah.gnu.org/gitweb/?p=libunistring.git
- conda_forge:    https://github.com/conda-forge/libunistring-feedstock
- pypi:
- pypi inspector:

### Explanation of changes:

- new version number
- Pass tests even on fail on OSX



[PKG-8997]: https://anaconda.atlassian.net/browse/PKG-8997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ